### PR TITLE
Force LTR to properly show in RTL languages

### DIFF
--- a/src/plotly-graph-card.ts
+++ b/src/plotly-graph-card.ts
@@ -96,6 +96,7 @@ export class PlotlyGraph extends HTMLElement {
               background: transparent;
               width: 100%;
               height: calc(100% - 5px);
+              direction: ltr;
             }
             ha-card > #plotly{
               width: 100px;


### PR DESCRIPTION
When the home assistant language is right-to-left the component totally cuts out the graph due to alignment:

![image](https://user-images.githubusercontent.com/37745463/212849954-d233fd9d-23ce-4601-8713-b65a78edde2c.png)

The fix will force LTR and make it show properly:

![image](https://user-images.githubusercontent.com/37745463/212850229-278724e6-4f62-4f87-945e-3bd568730b7d.png)
